### PR TITLE
[BUG] Fix bug with unclosed div element

### DIFF
--- a/classes/QM_Output_Memcache_Stats.php
+++ b/classes/QM_Output_Memcache_Stats.php
@@ -62,6 +62,7 @@ class QM_Output_Memcache_Stats extends QM_Output_Html {
 			echo '</tbody>';
 			echo '</table>';
 		}
+		echo '</div>';
 	}
 
 	/**


### PR DESCRIPTION
This plugin was not closing the primary div for the qm section.

This meant that some other sections were unavailable (including
configuration section, capability checks, and jetpack search section.)

**Note**: I'm looking at fixing some of the issues in this repo for use in one of our wordpress projects, as it's been really useful.

Is there any interest in fixing this up? If not we can use a fork of this repo.